### PR TITLE
Fix `cap` shaped `control` blocks

### DIFF
--- a/libs/scratch/core.typ
+++ b/libs/scratch/core.typ
@@ -300,7 +300,7 @@
       looks:     looks,
       sound:     sound,
       pen:       pen,
-      control:   control,
+      control:   content => control(content, bottom-notch: shape != "cap"),
       sensing:   sensing,
       variables: variables,
       lists:     lists,


### PR DESCRIPTION
This passes the info to `control` for whether a block should have the bottom notch, removing it from `stop` and `delete-this-clone` as expected.