### PR TITLE
chore: require Typst 0.15, drop generated manual from the package

### DIFF
--- a/manual/main.typ
+++ b/manual/main.typ
@@ -48,7 +48,7 @@ turn cw (15) degrees
 - *Version:* 0.3.0
 - *License:* MIT
 - *Repository:* #link("https://github.com/Loewe1000/blockst")[github.com/Loewe1000/blockst]
-- *Compiler requirement:* Typst 0.13.1+
+- *Compiler requirement:* Typst 0.15.0+
 - *Font requirement:* Designed for Helvetica Neue (Scratch look). On Linux/Windows install a compatible font (e.g. Nimbus Sans) or override via #link("#set-blockst")[set-blockst].
 
 = Core Rendering API <core-api>

--- a/scripts/publish-to-packages.sh
+++ b/scripts/publish-to-packages.sh
@@ -84,6 +84,7 @@ rsync -a --delete --delete-excluded \
   --exclude="*.pdf" \
   --exclude=".DS_Store" \
   --exclude="scripts/" \
+  --exclude="manual/main.html" \
   "$BLOCKST_DIR/" \
   "$TARGET_DIR/"
 

--- a/typst.toml
+++ b/typst.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/Loewe1000/blockst"
 keywords = ["scratch", "education", "programming", "blocks"]
 categories = ["visualization", "components", "languages"]
 disciplines = ["education", "computer-science"]
-compiler = "0.13.1"
+compiler = "0.15.0"
 exclude = [
 	".DS_Store",
 	"*.pdf",


### PR DESCRIPTION
Two small things ahead of the Universe submission for 0.3.0:

- `typst.toml` declares `compiler = "0.15.0"`. The floor was still `0.13.1`, which 0.3.0 has never been compiled against — this states what is actually verified. `manual/main.typ` says the same.
- `publish-to-packages.sh` stops copying `manual/main.html` into the submission. It is generated output (gitignored here, rebuilt by CI) and was 3 MB of an 8 MB PR against the Universe monorepo. `/manual` is excluded from the published archive anyway.

Note that raising the compiler floor means users on Typst 0.13/0.14 stay on `0.2.1`.